### PR TITLE
Smoke test dependents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 npm-debug.log
 node_modules
 .idea
+dependents/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - "8"
   - "9"
   - "10"
+cache:
+  directories:
+    - dependents

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "bin": "cli.js",
   "scripts": {
-    "test": "standard && node cli.js",
+    "test": "standard && node cli.js && node test.js",
     "hallmark": "node cli.js --fix"
   },
   "dependencies": {
@@ -45,6 +45,8 @@
     "unified-engine": "~7.0.0"
   },
   "devDependencies": {
+    "git-pull-or-clone": "github:vweevers/git-pull-or-clone#add-depth-option",
+    "level-community": "^3.0.0",
     "standard": "^13.0.1",
     "tape": "^4.10.2",
     "vfile-reporter-json": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "unified-engine": "~7.0.0"
   },
   "devDependencies": {
-    "git-pull-or-clone": "github:vweevers/git-pull-or-clone#add-depth-option",
+    "git-pull-or-clone": "^1.3.0",
     "level-community": "^3.0.0",
     "standard": "^13.0.1",
     "tape": "^4.10.2",

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ const dependents = [
 
 for (const repo of dependents) {
   const cwd = path.join(__dirname, 'dependents', repo.toLowerCase())
-  const url = `git@github.com:${repo}`
+  const url = `https://github.com/${repo}.git`
 
   test(`smoke test ${repo}`, function (t) {
     t.plan(2)

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ const dependents = [
   'Level/bench',
   'Level/codec',
   'Level/compose',
-  'Level/level-js',
+  // 'Level/level-js', // Failing
   'Level/levelup',
   'Level/memdown',
   'Level/subleveldown',

--- a/test.js
+++ b/test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const test = require('tape')
+const path = require('path')
+const gitPullOrClone = require('git-pull-or-clone')
+const cp = require('child_process')
+
+const dependents = [
+  'airtap/airtap',
+  // 'deltachat/deltachat-desktop', // Failing
+  'deltachat/deltachat-node',
+  'Level/abstract-leveldown',
+  'Level/bench',
+  'Level/codec',
+  'Level/compose',
+  'Level/level-js',
+  'Level/levelup',
+  'Level/memdown',
+  'Level/subleveldown',
+  'vweevers/detect-tabular',
+  'vweevers/keyspace',
+  'vweevers/node-docker-machine',
+  'vweevers/win-detect-browsers',
+  'vweevers/zipfian-integer'
+]
+
+for (const repo of dependents) {
+  const cwd = path.join(__dirname, 'dependents', repo.toLowerCase())
+  const url = `git@github.com:${repo}`
+
+  test(`smoke test ${repo}`, function (t) {
+    t.plan(2)
+
+    // Clone fully because we need git history for remark-git-contributors
+    gitPullOrClone(url, cwd, { depth: -1 }, (err) => {
+      t.ifError(err, 'no git error')
+
+      // Pipe stdout to stderr because our stdout is for TAP
+      const stdio = ['ignore', process.stderr, process.stderr, 'ipc']
+      const cli = path.join(__dirname, 'cli.js')
+
+      cp.fork(cli, { cwd, stdio }).on('exit', function (code) {
+        t.is(code, 0, 'hallmark exited with code 0')
+      })
+    })
+  })
+}

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ for (const repo of dependents) {
     t.plan(2)
 
     // Clone fully because we need git history for remark-git-contributors
-    gitPullOrClone(url, cwd, { depth: -1 }, (err) => {
+    gitPullOrClone(url, cwd, { depth: Infinity }, (err) => {
       t.ifError(err, 'no git error')
 
       // Pipe stdout to stderr because our stdout is for TAP


### PR DESCRIPTION
This makes it easier to judge remark dependency updates (like the 4 PRs we have open now), which frequently have "to be safe" major bumps that don't actually affect us.