### PR TITLE
Restore previous repo behavior of remark-validate-links

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -1,4 +1,4 @@
-module.exports = function (fix, validateLinks) {
+module.exports = function (fix, validateLinks, repo) {
   const preset = {
     plugins: [
       require('remark-lint'),
@@ -44,9 +44,11 @@ module.exports = function (fix, validateLinks) {
   // HTML anchors - as used in various Level readme's. Those readme's should be
   // updated to use markdown only.
   if (validateLinks) {
-    preset.plugins.push(
-      require('remark-validate-links')
-    )
+    preset.plugins.push([require('remark-validate-links'), {
+      // If we don't pass this, remark-validate-links tries to get the repo url
+      // from `git remote -v` which is not desirable for forks.
+      repository: repo || false
+    }])
   }
 
   return preset

--- a/options.js
+++ b/options.js
@@ -4,7 +4,7 @@ const color = require('supports-color').stdout
 const extensions = require('markdown-extensions')
 const processor = require('remark')
 
-module.exports = function (argv, packageOpts, files, cwd) {
+module.exports = function (argv, packageOpts, files, cwd, repo) {
   let reporter
   let reporterOptions
 
@@ -38,7 +38,7 @@ module.exports = function (argv, packageOpts, files, cwd) {
         test: /^table of contents$/i,
         summary: 'Click to expand'
       }],
-      require('./lint')(argv.fix, packageOpts.validateLinks !== false)
+      require('./lint')(argv.fix, packageOpts.validateLinks !== false, repo)
     ],
     settings: {
       // One style for code blocks, whether they have a language or not.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "deglob": "~4.0.0",
+    "find-root": "~1.1.0",
     "markdown-extensions": "~1.1.1",
-    "pkg-config": "~1.1.1",
     "remark": "~11.0.0",
     "remark-collapse": "~0.1.2",
     "remark-git-contributors": "~2.0.0",


### PR DESCRIPTION
Since 9.0.0, `remark-validate-links` tries to get the repo url from git remotes (which is not desirable for forks) rather than the `package.json`. Hallmark now reads `package.json` itself and passes the repo url to `remark-validate-links`.

I also inlined some code for finding & reading the `package.json` so that this doesn't have to be done 3 times over (by `pkg-config`, `deglob` and for getting the repo url).