### PR TITLE
Add remark-changelog

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -1,7 +1,9 @@
-module.exports = function (fix, validateLinks, repo) {
+module.exports = function (fix, cwd, validateLinks, repository) {
   const preset = {
     plugins: [
       require('remark-lint'),
+
+      [require('remark-changelog'), { cwd, fix, repository }],
 
       // These are not automatically fixed by remark-stringify
       require('remark-lint-no-undefined-references'),
@@ -44,7 +46,7 @@ module.exports = function (fix, validateLinks, repo) {
     preset.plugins.push([require('remark-validate-links'), {
       // If we don't pass this, remark-validate-links tries to get the repo url
       // from `git remote -v` which is not desirable for forks.
-      repository: repo || false
+      repository: repository || false
     }])
   }
 

--- a/options.js
+++ b/options.js
@@ -4,7 +4,7 @@ const color = require('supports-color').stdout
 const extensions = require('markdown-extensions')
 const processor = require('remark')
 
-module.exports = function (argv, packageOpts, files, cwd, repo) {
+module.exports = function (argv, packageOpts, files, cwd, repository) {
   let reporter
   let reporterOptions
 
@@ -33,7 +33,7 @@ module.exports = function (argv, packageOpts, files, cwd, repo) {
     plugins: [
       // Skip updating contributors table in lint mode
       fix ? [require('remark-git-contributors'), { contributors }] : null,
-      [require('remark-github'), { repository: repo }],
+      [require('remark-github'), { repository }],
       [require('remark-toc'), {
         maxDepth: 2,
         tight: true
@@ -42,7 +42,7 @@ module.exports = function (argv, packageOpts, files, cwd, repo) {
         test: /^table of contents$/i,
         summary: 'Click to expand'
       }],
-      require('./lint')(fix, packageOpts.validateLinks !== false, repo)
+      require('./lint')(fix, cwd, packageOpts.validateLinks !== false, repository)
     ].filter(Boolean),
     settings: {
       // One style for code blocks, whether they have a language or not.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "find-root": "~1.1.0",
     "markdown-extensions": "~1.1.1",
     "remark": "~11.0.0",
+    "remark-changelog": "~0.0.1",
     "remark-collapse": "~0.1.2",
     "remark-git-contributors": "~2.0.0",
     "remark-github": "~8.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "find-root": "~1.1.0",
     "markdown-extensions": "~1.1.1",
     "remark": "~11.0.0",
-    "remark-changelog": "github:vweevers/remark-changelog#1ee6077",
+    "remark-changelog": "~0.0.2",
     "remark-collapse": "~0.1.2",
     "remark-git-contributors": "~2.0.0",
     "remark-github": "~8.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "find-root": "~1.1.0",
     "markdown-extensions": "~1.1.1",
     "remark": "~11.0.0",
-    "remark-changelog": "~0.0.1",
+    "remark-changelog": "github:vweevers/remark-changelog#1ee6077",
     "remark-collapse": "~0.1.2",
     "remark-git-contributors": "~2.0.0",
     "remark-github": "~8.0.0",

--- a/test.js
+++ b/test.js
@@ -10,18 +10,18 @@ const dependents = [
   'airtap/airtap',
   // 'deltachat/deltachat-desktop', // Failing
   'deltachat/deltachat-node',
-  'Level/abstract-leveldown',
+  // 'Level/abstract-leveldown', // TODO: update links
   'Level/bench',
   'Level/codec',
   'Level/compose',
   // 'Level/level-js', // Failing
-  'Level/levelup',
-  'Level/memdown',
+  // 'Level/levelup', // TODO: update and reorder links
+  // 'Level/memdown', // TODO: update links
   'Level/subleveldown',
   'vweevers/detect-tabular',
   'vweevers/keyspace',
   'vweevers/node-docker-machine',
-  'vweevers/win-detect-browsers',
+  // 'vweevers/win-detect-browsers', // TODO: missing release
   'vweevers/zipfian-integer'
 ]
 

--- a/test.js
+++ b/test.js
@@ -32,8 +32,7 @@ for (const repo of dependents) {
   test(`smoke test ${repo}`, function (t) {
     t.plan(5)
 
-    // Clone fully because we need git history for remark-git-contributors
-    gitPullOrClone(url, cwd, { depth: Infinity }, (err) => {
+    pull(url, cwd, (err) => {
       t.ifError(err, 'no git error')
 
       // Pipe stdout to stderr because our stdout is for TAP
@@ -65,5 +64,13 @@ for (const repo of dependents) {
         })
       })
     })
+  })
+}
+
+function pull (url, cwd, callback) {
+  // Clone fully because we need git history for remark-git-contributors
+  gitPullOrClone(url, cwd, { depth: Infinity }, function (err) {
+    if (err) return callback(err)
+    cp.execFile('git', ['fetch', '--tags'], { cwd }, callback)
   })
 }

--- a/test.js
+++ b/test.js
@@ -10,18 +10,18 @@ const dependents = [
   'airtap/airtap',
   // 'deltachat/deltachat-desktop', // Failing
   'deltachat/deltachat-node',
-  // 'Level/abstract-leveldown', // TODO: update links
+  'Level/abstract-leveldown',
   'Level/bench',
   'Level/codec',
   'Level/compose',
   // 'Level/level-js', // Failing
-  // 'Level/levelup', // TODO: update and reorder links
-  // 'Level/memdown', // TODO: update links
+  'Level/levelup',
+  'Level/memdown',
   'Level/subleveldown',
   'vweevers/detect-tabular',
   'vweevers/keyspace',
   'vweevers/node-docker-machine',
-  // 'vweevers/win-detect-browsers', // TODO: missing release
+  'vweevers/win-detect-browsers',
   'vweevers/zipfian-integer'
 ]
 

--- a/test.js
+++ b/test.js
@@ -49,13 +49,15 @@ for (const repo of dependents) {
         cp.fork(cli, args, { cwd, stdio }).on('exit', function (code) {
           t.is(code, 0, 'hallmark fixer exited with code 0')
 
-          cp.execFile('git', ['diff'], { cwd }, function (err, stdout) {
+          cp.execFile('git', ['diff', '--color'], { cwd }, function (err, stdout) {
             const diff = (stdout || '').trim()
 
             t.ifError(err, 'no git error')
-            t.is(diff, '', 'no diff')
+            t.ok(diff === '', 'no diff')
 
             if (diff !== '') {
+              console.error(diff)
+
               // Start fresh on the next test run
               rimraf.sync(cwd, { glob: false })
             }


### PR DESCRIPTION
This [plugin](https://github.com/vweevers/remark-changelog) lints and fixes changelogs (among other things, it automatically adds links to `<version> - <date>` headers).

Only question is whether to make this (and the Keep A Changelog format) opt-in or not.